### PR TITLE
162 protect deployment to GitHub pages

### DIFF
--- a/.github/workflows/sphinx-pages.yml
+++ b/.github/workflows/sphinx-pages.yml
@@ -2,7 +2,7 @@ name: Build and Deploy
 on:
   push:
     branches:
-      162-protect-deployment-to-github-pages
+      main
 permissions:
   id-token: write  # Add this line to allow OIDC token access
   pages: write

--- a/.github/workflows/sphinx-pages.yml
+++ b/.github/workflows/sphinx-pages.yml
@@ -5,7 +5,7 @@ on:
       162-protect-deployment-to-github-pages
 permissions:
   id-token: write  # Add this line to allow OIDC token access
-
+  pages: write
 jobs:
   build:
     # Specify runner +  build & upload the static files as an artifact

--- a/.github/workflows/sphinx-pages.yml
+++ b/.github/workflows/sphinx-pages.yml
@@ -10,6 +10,7 @@ jobs:
     # Specify runner +  build & upload the static files as an artifact
     runs-on: ubuntu-latest
     steps:
+      - uses: actions/checkout@v4
       - uses: actions/setup-python@v5
       - name: Install dependencies
         run: |

--- a/.github/workflows/sphinx-pages.yml
+++ b/.github/workflows/sphinx-pages.yml
@@ -3,6 +3,9 @@ on:
   push:
     branches:
       162-protect-deployment-to-github-pages
+permissions:
+  id-token: write  # Add this line to allow OIDC token access
+
 jobs:
   build:
     # Specify runner +  build & upload the static files as an artifact

--- a/.github/workflows/sphinx-pages.yml
+++ b/.github/workflows/sphinx-pages.yml
@@ -3,8 +3,6 @@ on:
   push:
     branches:
       162-protect-deployment-to-github-pages
-permissions:
-  contents: write
 jobs:
   build:
     # Specify runner +  build & upload the static files as an artifact

--- a/.github/workflows/sphinx-pages.yml
+++ b/.github/workflows/sphinx-pages.yml
@@ -2,25 +2,37 @@ name: Build and Deploy
 on:
   push:
     branches:
-      - main  # Trigger only on pushes to the main branch
+      162-protect-deployment-to-github-pages
 permissions:
   contents: write
 jobs:
-  build-and-deploy:
-    concurrency: ci-${{ github.ref }} # Recommended if you intend to make multiple deployments in quick succession.
+  build:
+    # Specify runner +  build & upload the static files as an artifact
     runs-on: ubuntu-latest
     steps:
-      - name: Checkout 🛎️
-        uses: actions/checkout@v4
-
       - uses: actions/setup-python@v5
       - name: Install dependencies
         run: |
           pip install sphinx sphinx_rtd_theme myst_parser sphinxcontrib-mermaid
-      - name: Sphinx build
+      - name: Build static files
+        id: build
         run: |
-          sphinx-build webcentral/doc/06_sphinx/source build      
-      - name: Deploy 🚀
-        uses: JamesIves/github-pages-deploy-action@v4
+          sphinx-build webcentral/doc/06_sphinx/source build/
+      - name: Upload static files as artifact
+        id: deployment
+        uses: actions/upload-pages-artifact@v3 # or specific "vX.X.X" version tag for this action
         with:
-          folder: build # The folder the action should deploy.
+          path: build/
+
+  # Deployment job
+  deploy:
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    runs-on: ubuntu-latest
+    needs: build
+    steps:
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4
+

--- a/webcentral/doc/06_sphinx/source/HowTo/create_dump_for_repo.md
+++ b/webcentral/doc/06_sphinx/source/HowTo/create_dump_for_repo.md
@@ -25,3 +25,4 @@ The following command creates a SQL-dump and puts the file into the `postgres/`-
 ./run dump_db postgres/new_dump.sql
 ```
 This dump can now be included into the git repository.
+This is a test.

--- a/webcentral/doc/06_sphinx/source/HowTo/create_dump_for_repo.md
+++ b/webcentral/doc/06_sphinx/source/HowTo/create_dump_for_repo.md
@@ -25,4 +25,4 @@ The following command creates a SQL-dump and puts the file into the `postgres/`-
 ./run dump_db postgres/new_dump.sql
 ```
 This dump can now be included into the git repository.
-This is a test.
+This is a test. Another test


### PR DESCRIPTION
- changed sphinx build and deploy github actions workflow to deploy directly to github pages without pushing to branch "gh-pages". 