### PR TITLE
only show _de and _en field in translation field

### DIFF
--- a/webcentral/src/templates/admin/Datasets/history/change_form.html
+++ b/webcentral/src/templates/admin/Datasets/history/change_form.html
@@ -94,9 +94,9 @@
           </thead>
           <tbody>
             {% for key in currentStateStringified.keys %}
-              
+
               {% if not key|stringformat:"s_de" in currentStateStringified.keys %}
-              
+
                 {% if rollbackStateStringified|get_item:key !=  currentStateStringified|get_item:key %}
 
                   <tr style="background-color: #87860f">
@@ -111,7 +111,8 @@
                     <td>{{ rollbackStateStringified|get_item:key }}</td>
                   </tr>
                 {% endif %}
-              {% endif %} 
+              {% endif %}
+
             </tr>
           {% endfor %}
         </tbody>

--- a/webcentral/src/templates/admin/Datasets/history/change_form.html
+++ b/webcentral/src/templates/admin/Datasets/history/change_form.html
@@ -94,21 +94,24 @@
           </thead>
           <tbody>
             {% for key in currentStateStringified.keys %}
+              
+              {% if not key|stringformat:"s_de" in currentStateStringified.keys %}
+              
+                {% if rollbackStateStringified|get_item:key !=  currentStateStringified|get_item:key %}
 
-              {% if rollbackStateStringified|get_item:key !=  currentStateStringified|get_item:key %}
-
-                <tr style="background-color: #87860f">
-                  <td>{{ key }}</td>
-                  <td>{{ currentStateStringified|get_item:key }}</td>
-                  <td>{{ rollbackStateStringified|get_item:key }}</td>
-                </tr>
-              {% else %}
-                <tr>
-                  <td>{{ key }}</td>
-                  <td>{{ currentStateStringified|get_item:key }}</td>
-                  <td>{{ rollbackStateStringified|get_item:key }}</td>
-                </tr>
-              {% endif %}
+                  <tr style="background-color: #87860f">
+                    <td>{{ key }}</td>
+                    <td>{{ currentStateStringified|get_item:key }}</td>
+                    <td>{{ rollbackStateStringified|get_item:key }}</td>
+                  </tr>
+                {% else %}
+                  <tr>
+                    <td>{{ key }}</td>
+                    <td>{{ currentStateStringified|get_item:key }}</td>
+                    <td>{{ rollbackStateStringified|get_item:key }}</td>
+                  </tr>
+                {% endif %}
+              {% endif %} 
             </tr>
           {% endfor %}
         </tbody>

--- a/webcentral/src/templates/admin/TechnicalStandards/history/change_form.html
+++ b/webcentral/src/templates/admin/TechnicalStandards/history/change_form.html
@@ -94,9 +94,9 @@
           </thead>
           <tbody>
             {% for key in currentStateStringified.keys %}
-              
+
               {% if not key|stringformat:"s_de" in currentStateStringified.keys %}
-              
+
                 {% if rollbackStateStringified|get_item:key !=  currentStateStringified|get_item:key %}
 
                   <tr style="background-color: #87860f">
@@ -111,9 +111,12 @@
                     <td>{{ rollbackStateStringified|get_item:key }}</td>
                   </tr>
                 {% endif %}
-              {% endif %} 
+              {% endif %}
+
             </tr>
-          {% endfor %}        </tbody>
+          {% endfor %}
+
+        </tbody>
       </table>
 
       {% block after_related_objects %}{% endblock %}

--- a/webcentral/src/templates/admin/TechnicalStandards/history/change_form.html
+++ b/webcentral/src/templates/admin/TechnicalStandards/history/change_form.html
@@ -94,24 +94,26 @@
           </thead>
           <tbody>
             {% for key in currentStateStringified.keys %}
+              
+              {% if not key|stringformat:"s_de" in currentStateStringified.keys %}
+              
+                {% if rollbackStateStringified|get_item:key !=  currentStateStringified|get_item:key %}
 
-              {% if rollbackStateStringified|get_item:key !=  currentStateStringified|get_item:key %}
-
-                <tr style="background-color: #87860f">
-                  <td>{{ key }}</td>
-                  <td>{{ currentStateStringified|get_item:key }}</td>
-                  <td>{{ rollbackStateStringified|get_item:key }}</td>
-                </tr>
-              {% else %}
-                <tr>
-                  <td>{{ key }}</td>
-                  <td>{{ currentStateStringified|get_item:key }}</td>
-                  <td>{{ rollbackStateStringified|get_item:key }}</td>
-                </tr>
-              {% endif %}
+                  <tr style="background-color: #87860f">
+                    <td>{{ key }}</td>
+                    <td>{{ currentStateStringified|get_item:key }}</td>
+                    <td>{{ rollbackStateStringified|get_item:key }}</td>
+                  </tr>
+                {% else %}
+                  <tr>
+                    <td>{{ key }}</td>
+                    <td>{{ currentStateStringified|get_item:key }}</td>
+                    <td>{{ rollbackStateStringified|get_item:key }}</td>
+                  </tr>
+                {% endif %}
+              {% endif %} 
             </tr>
-          {% endfor %}
-        </tbody>
+          {% endfor %}        </tbody>
       </table>
 
       {% block after_related_objects %}{% endblock %}

--- a/webcentral/src/templates/admin/businessModel/history/change_form.html
+++ b/webcentral/src/templates/admin/businessModel/history/change_form.html
@@ -94,9 +94,9 @@
           </thead>
           <tbody>
             {% for key in currentStateStringified.keys %}
-              
+
               {% if not key|stringformat:"s_de" in currentStateStringified.keys %}
-              
+
                 {% if rollbackStateStringified|get_item:key !=  currentStateStringified|get_item:key %}
 
                   <tr style="background-color: #87860f">
@@ -111,7 +111,8 @@
                     <td>{{ rollbackStateStringified|get_item:key }}</td>
                   </tr>
                 {% endif %}
-              {% endif %} 
+              {% endif %}
+
             </tr>
           {% endfor %}
         </tbody>

--- a/webcentral/src/templates/admin/businessModel/history/change_form.html
+++ b/webcentral/src/templates/admin/businessModel/history/change_form.html
@@ -94,21 +94,24 @@
           </thead>
           <tbody>
             {% for key in currentStateStringified.keys %}
+              
+              {% if not key|stringformat:"s_de" in currentStateStringified.keys %}
+              
+                {% if rollbackStateStringified|get_item:key !=  currentStateStringified|get_item:key %}
 
-              {% if rollbackStateStringified|get_item:key !=  currentStateStringified|get_item:key %}
-
-                <tr style="background-color: #87860f">
-                  <td>{{ key }}</td>
-                  <td>{{ currentStateStringified|get_item:key }}</td>
-                  <td>{{ rollbackStateStringified|get_item:key }}</td>
-                </tr>
-              {% else %}
-                <tr>
-                  <td>{{ key }}</td>
-                  <td>{{ currentStateStringified|get_item:key }}</td>
-                  <td>{{ rollbackStateStringified|get_item:key }}</td>
-                </tr>
-              {% endif %}
+                  <tr style="background-color: #87860f">
+                    <td>{{ key }}</td>
+                    <td>{{ currentStateStringified|get_item:key }}</td>
+                    <td>{{ rollbackStateStringified|get_item:key }}</td>
+                  </tr>
+                {% else %}
+                  <tr>
+                    <td>{{ key }}</td>
+                    <td>{{ currentStateStringified|get_item:key }}</td>
+                    <td>{{ rollbackStateStringified|get_item:key }}</td>
+                  </tr>
+                {% endif %}
+              {% endif %} 
             </tr>
           {% endfor %}
         </tbody>

--- a/webcentral/src/templates/admin/protocols/history/change_form.html
+++ b/webcentral/src/templates/admin/protocols/history/change_form.html
@@ -94,9 +94,9 @@
           </thead>
           <tbody>
             {% for key in currentStateStringified.keys %}
-              
+
               {% if not key|stringformat:"s_de" in currentStateStringified.keys %}
-              
+
                 {% if rollbackStateStringified|get_item:key !=  currentStateStringified|get_item:key %}
 
                   <tr style="background-color: #87860f">
@@ -111,9 +111,12 @@
                     <td>{{ rollbackStateStringified|get_item:key }}</td>
                   </tr>
                 {% endif %}
-              {% endif %} 
+              {% endif %}
+
             </tr>
-          {% endfor %}        </tbody>
+          {% endfor %}
+
+        </tbody>
       </table>
 
       {% block after_related_objects %}{% endblock %}

--- a/webcentral/src/templates/admin/protocols/history/change_form.html
+++ b/webcentral/src/templates/admin/protocols/history/change_form.html
@@ -94,24 +94,26 @@
           </thead>
           <tbody>
             {% for key in currentStateStringified.keys %}
+              
+              {% if not key|stringformat:"s_de" in currentStateStringified.keys %}
+              
+                {% if rollbackStateStringified|get_item:key !=  currentStateStringified|get_item:key %}
 
-              {% if rollbackStateStringified|get_item:key !=  currentStateStringified|get_item:key %}
-
-                <tr style="background-color: #87860f">
-                  <td>{{ key }}</td>
-                  <td>{{ currentStateStringified|get_item:key }}</td>
-                  <td>{{ rollbackStateStringified|get_item:key }}</td>
-                </tr>
-              {% else %}
-                <tr>
-                  <td>{{ key }}</td>
-                  <td>{{ currentStateStringified|get_item:key }}</td>
-                  <td>{{ rollbackStateStringified|get_item:key }}</td>
-                </tr>
-              {% endif %}
+                  <tr style="background-color: #87860f">
+                    <td>{{ key }}</td>
+                    <td>{{ currentStateStringified|get_item:key }}</td>
+                    <td>{{ rollbackStateStringified|get_item:key }}</td>
+                  </tr>
+                {% else %}
+                  <tr>
+                    <td>{{ key }}</td>
+                    <td>{{ currentStateStringified|get_item:key }}</td>
+                    <td>{{ rollbackStateStringified|get_item:key }}</td>
+                  </tr>
+                {% endif %}
+              {% endif %} 
             </tr>
-          {% endfor %}
-        </tbody>
+          {% endfor %}        </tbody>
       </table>
 
       {% block after_related_objects %}{% endblock %}

--- a/webcentral/src/templates/admin/publications/history/change_form.html
+++ b/webcentral/src/templates/admin/publications/history/change_form.html
@@ -94,9 +94,9 @@
           </thead>
           <tbody>
             {% for key in currentStateStringified.keys %}
-              
+
               {% if not key|stringformat:"s_de" in currentStateStringified.keys %}
-              
+
                 {% if rollbackStateStringified|get_item:key !=  currentStateStringified|get_item:key %}
 
                   <tr style="background-color: #87860f">
@@ -111,7 +111,8 @@
                     <td>{{ rollbackStateStringified|get_item:key }}</td>
                   </tr>
                 {% endif %}
-              {% endif %} 
+              {% endif %}
+
             </tr>
           {% endfor %}
         </tbody>

--- a/webcentral/src/templates/admin/publications/history/change_form.html
+++ b/webcentral/src/templates/admin/publications/history/change_form.html
@@ -94,21 +94,24 @@
           </thead>
           <tbody>
             {% for key in currentStateStringified.keys %}
+              
+              {% if not key|stringformat:"s_de" in currentStateStringified.keys %}
+              
+                {% if rollbackStateStringified|get_item:key !=  currentStateStringified|get_item:key %}
 
-              {% if rollbackStateStringified|get_item:key !=  currentStateStringified|get_item:key %}
-
-                <tr style="background-color: #87860f">
-                  <td>{{ key }}</td>
-                  <td>{{ currentStateStringified|get_item:key }}</td>
-                  <td>{{ rollbackStateStringified|get_item:key }}</td>
-                </tr>
-              {% else %}
-                <tr>
-                  <td>{{ key }}</td>
-                  <td>{{ currentStateStringified|get_item:key }}</td>
-                  <td>{{ rollbackStateStringified|get_item:key }}</td>
-                </tr>
-              {% endif %}
+                  <tr style="background-color: #87860f">
+                    <td>{{ key }}</td>
+                    <td>{{ currentStateStringified|get_item:key }}</td>
+                    <td>{{ rollbackStateStringified|get_item:key }}</td>
+                  </tr>
+                {% else %}
+                  <tr>
+                    <td>{{ key }}</td>
+                    <td>{{ currentStateStringified|get_item:key }}</td>
+                    <td>{{ rollbackStateStringified|get_item:key }}</td>
+                  </tr>
+                {% endif %}
+              {% endif %} 
             </tr>
           {% endfor %}
         </tbody>


### PR DESCRIPTION
On the website, when checking the differences between the current state of an itema and the stringified rollback state of the item, a false yellow highliting can occur, when the false language with loaded into the translation field. Here is an example:
When the language is set to german, only the differences are shown:
![grafik](https://github.com/user-attachments/assets/7a24f7b2-191e-4220-b08a-b3a4f08db695)
When the language is changed to english, the attributes are updated with the english representations and false differences are sown:
![grafik](https://github.com/user-attachments/assets/f1ff9fb1-59ce-4f7c-89ed-3f9d354712cb)
To solve this problem, for translated attributes, only the translation field should be shown. This is implemented in that pull request. The details page for the tools now looks like this:
![grafik](https://github.com/user-attachments/assets/89962d66-4cd4-4a0f-b121-8fb6f4e17727)
